### PR TITLE
27 add option to add acl function to prevent recursively adding permission

### DIFF
--- a/AzureDataLakeManagement/AzureDataLakeManagement.psd1
+++ b/AzureDataLakeManagement/AzureDataLakeManagement.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AzureDataLakeManagement.psm1'
 
 # Version number of this module.
-ModuleVersion = '2024.1.1'
+ModuleVersion = '2025.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ To contribute to this project please view the GitHub project at https://github.c
 
 ## Version History:
 
+- 2025.1.1 - 01/09/2025
+Issue 27 - Added optional switch to set-DataLakeFolderACL and remove-DataLakeFolderACL functions to enable the user to not recursively apply permissions on children of the path specified.
+
 - 2024.1.1 - 01/09/2024
 Issue 22 - Fixed issue where a lack of Azure Permissions to Microsoft.Storage/storageAccounts/listKeys/action would cause failure to execute even with correct AzureAD permissions on objects.
 


### PR DESCRIPTION
Added optional switch to set-DataLakeFolderACL and remove-DataLakeFolderACL functions to enable the user to not recursively apply permissions on children of the path specified.

Closes #27 